### PR TITLE
suppress predicted_gender and predicted_age events

### DIFF
--- a/discord_data/parse.py
+++ b/discord_data/parse.py
@@ -134,7 +134,13 @@ def parse_activity(
     """
     Return useful fields from the JSON blobs
     """
-    yield from map(_parse_activity_blob, parse_raw_activity(events_dir, logger))
+    for x in parse_raw_activity(events_dir, logger):
+        if x.get('predicted_gender') is not None or x.get('predicted_age') is not None:
+            # newer (2023ish) export have a few (2-3) of these events
+            # they don't have any useful info apart from some probabilites of user's gender/age
+            # don't have any event_id or event_type either so we can't really parse them
+            continue
+        yield _parse_activity_blob(x)
 
 
 def parse_raw_activity(


### PR DESCRIPTION
Started getting these in newer discord exports

they look like this in raw export

    {'user_id': '605898501150343168', 'predicted_gender': 'male', 'probability': 0.9174297451972961, 'prob_male': 0.9174297451972961, 'prob_female': 0.07241026312112808, 'prob_non_binary_gender_expansive': 0.010159985162317753, 'model_version': '2023-03-08T00:00:00.000000Z',     'day_pt': '2023-03-15 00:00:00 UTC'}
    {'user_id': '605898501150343168', 'predicted_age': '35+', 'probability': 0.503736138343811, 'prob_13_17': 0.1455467939376831, 'prob_18_24': 0.17453151941299438, 'prob_25_34': 0.17618557810783386, 'prob_35_over': 0.503736138343811, 'model_version': '2023-03-01T00:00:00.000    000Z', 'day_pt': '2023-03-08 00:00:00 UTC'}

causing parser to crash because they don't have any event id/type

perhaps even better would be to make everything a bit more defensive and yield `Res[Activity]`, but probably worth skipping these anyway